### PR TITLE
ticket-7: use angle up and down, and a nested comp

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ import {
 } from "react-router-dom";
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faFilter, faThumbsUp } from '@fortawesome/free-solid-svg-icons';
+import { faFilter, faThumbsUp, faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
 import { fab } from '@fortawesome/free-brands-svg-icons';
 import { library } from '@fortawesome/fontawesome-svg-core'
 
@@ -26,7 +26,7 @@ import TopStoriesComponent from './components/list/TopStoriesComponent';
 import BestStoriesComponent from './components/list/BestStoriesComponent';
 import NewStoriesComponent from './components/list/NewStoriesComponent';
 
-library.add(faFilter, faThumbsUp, fab);
+library.add(faFilter, faThumbsUp, faAngleDown, faAngleUp, fab);
 
 
 class App extends React.Component {

--- a/src/components/item/CommentComponent.jsx
+++ b/src/components/item/CommentComponent.jsx
@@ -3,19 +3,19 @@ import React from 'react';
 import ListGroup from 'react-bootstrap/ListGroup';
 
 import ApiEndpoints from '../../utils/ApiEndpoints';
+import htmlDecode from '../../utils/helpers';
+import CommentListComponent from '../list/CommentListComponent';
 
-function htmlDecode(input)
-{
-    var doc = new DOMParser().parseFromString(input, "text/html");
-    return doc.documentElement.textContent;
-}
+
 
 class CommentComponent extends React.Component {
 
     constructor(props) {
         super(props);
         this.state = {
-            comments: []
+            comments: [],
+            kids: [],
+            expanded: false,
         }
     }
 
@@ -33,15 +33,16 @@ class CommentComponent extends React.Component {
 
     render() {
         let comments = this.state.comments;
+        let depth = (this.props.depth || 0) + 1;
         if (comments.length > 0) {
             return (
                 <ListGroup variant="flush">
                     Comments
-                    {comments.map(function(comment) {
+                    {comments.map((comment) => {
                         if (!comment.deleted) {
                             return (<ListGroup.Item key={"itm-" + comment.id}>
                                     <div key={comment.id}>{htmlDecode(comment.text)}</div>
-                                    <div><i>{(comment.kids && comment.kids.length) || "no"} replies</i></div>
+                                    <CommentListComponent kids={comment.kids} depth={depth}/>
                                 </ListGroup.Item>);
                         } else {
                             return <div key={comment.id}><i>Deleted.</i></div>

--- a/src/components/list/CommentListComponent.jsx
+++ b/src/components/list/CommentListComponent.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import ListGroup from 'react-bootstrap/ListGroup';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import ApiEndpoints from '../../utils/ApiEndpoints';
+import htmlDecode from '../../utils/helpers';
+
+const MAX_COMMENT_DEPTH = 5;
+
+class CommentListComponent extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            expanded: false,
+            replies: []
+        }
+    }
+
+    updateExpanded = () => {
+        let oldExpanded = this.state.expanded;
+        this.setState({
+            expanded: !oldExpanded,
+            replies: !oldExpanded ? this.state.replies : []
+        });
+    }
+
+    updateReplies = (newReplies) => {
+        this.setState({
+            replies: newReplies
+        })
+    }
+
+    fetchReplies = () => {
+        ApiEndpoints.getBulkNewsItems(this.props.kids, this.updateReplies);
+    } 
+
+    render() {
+        // quick no displays
+        // 1. no replies
+        let haveReplies = !!(this.props.kids && this.props.kids.length);
+        if (!haveReplies) {
+            return <div className="Comment"><i>no replies</i></div>
+        }
+        // 2. maximum depth reached
+        let depth = (this.props.depth || 0) + 1;
+        if (depth > MAX_COMMENT_DEPTH) {
+            return <div className="Comment"><i>Continue this thread...</i></div>
+        }
+
+        let expanded = this.state.expanded;
+        let icon = expanded ? "angle-up" : "angle-down";
+        let replies = this.state.replies;
+        return (
+            <div>
+            <i className="Comment" onClick={()=>{this.updateExpanded()}}>
+                <FontAwesomeIcon icon={icon} />
+                {this.props.kids.length} replies
+            </i>
+            {expanded && this.fetchReplies()}
+            {expanded && <ListGroup variant="flush">
+                    {replies.map((comment) => {
+                        if (!comment.deleted) {
+                            return (<ListGroup.Item key={"itm-" + comment.id}>
+                                    <div key={comment.id}>{htmlDecode(comment.text)}</div>
+                                    <CommentListComponent kids={comment.kids} depth={depth}/>
+                                </ListGroup.Item>);
+                        } else {
+                            return <div key={comment.id}><i>Deleted.</i></div>
+                        }
+                    })}
+                </ListGroup>
+            }
+            </div>
+        );
+    }
+}
+export default CommentListComponent;

--- a/src/utils/ApiEndpoints.js
+++ b/src/utils/ApiEndpoints.js
@@ -3,6 +3,7 @@ let cursor = 0;
 let limitCounter = 30;
 let newsItems = []
 
+
 class ApiEndpoints {
     static getNewsItem(itemId, callback) {
         let request = new Request(`${BASE_URL}/v0/item/${itemId}.json`);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,0 +1,7 @@
+
+function htmlDecode(input)
+{
+    var doc = new DOMParser().parseFromString(input, "text/html");
+    return doc.documentElement.textContent;
+}
+export default htmlDecode;


### PR DESCRIPTION
under comment there is a text indicating:
- how many comments and an angle down if the comments are not expanded (angle up and comments expanded)
- no replies, if no comments (or replies)
- Continue this thread... (not implemented, it should be perma-links to comments)
remaining work:
- continue this thread
- how to destroy/unmount child comments if all comments/top comments are closed. currently have a warning in console for this.
